### PR TITLE
Remove superfluous warning

### DIFF
--- a/lib/parent.pm
+++ b/lib/parent.pm
@@ -12,10 +12,6 @@ sub import {
         shift @_;
     } else {
         for ( my @filename = @_ ) {
-            if ( $_ eq $inheritor ) {
-                warn "Class '$inheritor' tried to inherit from itself\n";
-            };
-
             s{::|'}{/}g;
             require "$_.pm"; # dies if the file is not found
         }
@@ -23,7 +19,7 @@ sub import {
 
     {
         no strict 'refs';
-        push @{"$inheritor\::ISA"}, @_;
+        push @{"$inheritor\::ISA"}, @_; # dies if a loop is detected
     };
 };
 
@@ -93,19 +89,6 @@ either C<.pm> or C<.pmc>), use the following code:
   package MySecondPlugin;
   require './plugins/custom.plugin'; # contains Plugin::Custom
   use parent -norequire, 'Plugin::Custom';
-
-=head1 DIAGNOSTICS
-
-=over 4
-
-=item Class 'Foo' tried to inherit from itself
-
-Attempting to inherit from yourself generates a warning.
-
-    package Foo;
-    use parent 'Foo';
-
-=back
 
 =head1 HISTORY
 

--- a/t/parent.t
+++ b/t/parent.t
@@ -9,7 +9,7 @@ BEGIN {
 }
 
 use strict;
-use Test::More tests => 10;
+use Test::More tests => 9;
 
 use_ok('parent');
 
@@ -65,13 +65,6 @@ like( $@, $expected, 'baseclass that does not exist');
 
 eval q{use parent 'reallyReAlLyNotexists'};
 like( $@, $expected, '  still failing on 2nd load');
-{
-    my $warning;
-    local $SIG{__WARN__} = sub { $warning = shift };
-    eval q{package HomoGenous; use parent 'HomoGenous';};
-    like($warning, q{/^Class 'HomoGenous' tried to inherit from itself/},
-                                          '  self-inheriting');
-}
 
 {
     BEGIN { $Has::Version_0::VERSION = 0 }


### PR DESCRIPTION
This warning has always bugged me.
1. It can only detect self-inheritance, not loops (Foo → Bar → Baz → Foo).
2. It does not prevent the `require` from being done, and because `%ISA` always contains an entry for the package being loaded while it’s being loaded, it’s harmless to “circularly” `require` anyway.
3. The `push` to `@ISA` dies if there is an inheritance loop (and it detects _loops_ – not just self-inheritance).
4. Even if the warning served any purpose, it is never thrown in the `-norequire` case anyway.

It is that last point, the inconsistency between `-norequire` and non, that really bugs me. Surely if the warning serves a purpose, it should be thrown consistently? Or else the message should reflect the fact that it applies to one case but not the other. But that brings me to all the points – what purpose _does_ it serve? When I try to find any, I come up empty.

The only explanation I can come up with about why this warning exists is that `base.pm` has a warning like that – I find no actual reason for it to exist in `parent.pm`.

And if it has none, then it should go.
