### PR TITLE
real fix for missing Config::non_bincompat_options on older perl

### DIFF
--- a/t/parent-pmc.t
+++ b/t/parent-pmc.t
@@ -14,7 +14,7 @@ use lib 't/lib';
 
 plan skip_all => ".pmc are only available with 5.6 and later" if $] < 5.006;
 my $no_pmc;
-if( exists $Config::{non_bincompat_options}) {
+if( defined &Config::non_bincompat_options ) {
     foreach(Config::non_bincompat_options()) {
        if($_ eq "PERL_DISABLE_PMC"){
            $no_pmc = 1;


### PR DESCRIPTION
The fix for older perls in 0.230 doesn't work.  This repairs it.
