### PR TITLE
fix pmc test under PERL_DISABLE_PMC on old perl

### DIFF
--- a/t/parent-pmc.t
+++ b/t/parent-pmc.t
@@ -13,16 +13,10 @@ use Config;
 use lib 't/lib';
 
 plan skip_all => ".pmc are only available with 5.6 and later" if $] < 5.006;
-my $no_pmc;
 
-if (Config->can('non_bincompat_options')) {
-    foreach(Config::non_bincompat_options()) {
-       if($_ eq "PERL_DISABLE_PMC"){
-           $no_pmc = 1;
-           last;
-       }
-    }
-};
+my $no_pmc = defined &Config::non_bincompat_options
+    ? (grep $_ eq 'PERL_DISABLE_PMC', Config::non_bincompat_options())
+    : ($Config::Config{ccflags} =~ /-DPERL_DISABLE_PMC\b/);
 plan skip_all => ".pmc are disabled in this perl"
     if $no_pmc;
 plan tests => 3;


### PR DESCRIPTION
Older versions of perl don't have Config::non_bincompat_options, but
they still support PERL_DISABLE_PMC.  Search ccflags for the flag in
this case.

Fixes RT#102626
