### PR TITLE
Switch from «use vars» to «our»

### DIFF
--- a/lib/parent.pm
+++ b/lib/parent.pm
@@ -1,7 +1,7 @@
 package parent;
 use strict;
-use vars qw($VERSION);
-$VERSION = '0.236';
+
+our $VERSION = '0.236';
 
 sub import {
     my $class = shift;

--- a/t/parent-pmc.t
+++ b/t/parent-pmc.t
@@ -35,7 +35,7 @@ plan skip_all => 'Perl is built with PERL_DISABLE_PMC' unless $pmc;
 
 plan tests => 3;
 
-use vars qw($got_here);
+our $got_here;
 
 my $res = eval q{
     package MyTest;

--- a/t/parent-returns-false.t
+++ b/t/parent-returns-false.t
@@ -11,7 +11,7 @@ use strict;
 use Test::More tests => 2;
 use lib 't/lib';
 
-use vars qw($got_here);
+our $got_here;
 
 my $res = eval q{
     package MyTest;

--- a/t/parent.t
+++ b/t/parent.t
@@ -16,7 +16,7 @@ use_ok('parent');
 
 package No::Version;
 
-use vars qw($Foo);
+our $Foo;
 sub VERSION { 42 }
 
 package Test::Version;


### PR DESCRIPTION
The former is deprecated and has a non-insignificant cost of loading a
module.