### PR TITLE
Enhance SEE ALSO section to include parent::versioned

### DIFF
--- a/lib/parent.pm
+++ b/lib/parent.pm
@@ -99,7 +99,15 @@ that had accumulated in it.
 
 =head1 SEE ALSO
 
-L<base>
+=over 4
+
+=item L<base>
+
+=item L<parent::versioned>
+
+A fork of L<parent> that provides version checking in parent class modules.
+
+=back
 
 =head1 AUTHORS AND CONTRIBUTORS
 


### PR DESCRIPTION
If you like, you can merge in this PR to add parent::versioned to the SEE ALSO section in parent's POD.  I did not touch the Changes file because this would presumably simply make it into a future release, but is not important enough to warrant a new release on its own.