### PR TITLE
move Test::More to a test prereq rather than runtime

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,10 @@ WriteMakefile1(
     'ABSTRACT_FROM'   => 'lib/parent.pm', # retrieve abstract from module
     'AUTHOR'          => 'Max Maischein <corion@cpan.org>',
     'VERSION_FROM'    => "lib/parent.pm", # finds $VERSION
-    'PREREQ_PM'       => { Test::More => 0.40 },
+    'PREREQ_PM'       => {},
+    'TEST_REQUIRES' => {
+        'Test::More' => '0.40',
+    },
     # parent.pm joined the core with 5.10.1
     # 5.12 fixed the @INC order so that site/ comes before perl/
     # So we only install into perl/ for versions between the two
@@ -28,12 +31,20 @@ WriteMakefile1(
 
 1;
 
-sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.21.
+sub WriteMakefile1 {  #Compatibility code for old versions of EU::MM. Written by Alexandr Ciornii, version 2. Added by eumm-upgrade.
     my %params=@_;
     my $eumm_version=$ExtUtils::MakeMaker::VERSION;
     $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
+    if ($params{AUTHOR} and ref($params{AUTHOR}) eq 'ARRAY' and $eumm_version < 6.5705) {
+        $params{META_ADD}->{author}=$params{AUTHOR};
+        $params{AUTHOR}=join(', ',@{$params{AUTHOR}});
+    }
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.64) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
     if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
         $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };
@@ -44,9 +55,6 @@ sub WriteMakefile1 {  #Written by Alexandr Ciornii, version 0.21.
     delete $params{META_MERGE} if $eumm_version < 6.46;
     delete $params{META_ADD} if $eumm_version < 6.46;
     delete $params{LICENSE} if $eumm_version < 6.31;
-    delete $params{AUTHOR} if $] < 5.005;
-    delete $params{ABSTRACT_FROM} if $] < 5.005;
-    delete $params{BINARY_LOCATION} if $] < 5.005;
 
     WriteMakefile(%params);
 }


### PR DESCRIPTION
Updates the eumm-upgrade code to cope with newer EUMM arguments, and
move the Test::More dependency to be for tests, not runtime.