### PR TITLE
Harden parent tests against possible error message changes coming in blead

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.239 2022-12-06
+    . Harden against changes to require error messages. The '@INC contains'
+      may change in a future release of perl, this hardens the test to
+      not be sensitive to the exact words chosen. See:
+      https://github.com/Perl/perl5/pull/20547
+
 0.238 2020-02-07
     . Move the prerequisite Test::More from being a runtime prerequisite
       to a test time / build time prerequisite (PR #11, by Haarg)

--- a/lib/parent.pm
+++ b/lib/parent.pm
@@ -1,7 +1,7 @@
 package parent;
 use strict;
 
-our $VERSION = '0.238';
+our $VERSION = '0.239';
 
 sub import {
     my $class = shift;

--- a/t/parent.t
+++ b/t/parent.t
@@ -56,8 +56,8 @@ is( $Eval1::VERSION, '1.01' );
 
 is( $Eval2::VERSION, '1.02' );
 
-my $expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(\@INC contains:/};
-$expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(you may need to install the reallyReAlLyNotexists module\) \(\@INC contains:/}
+my $expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(\@INC[\w ]+:/};
+$expected= q{/^Can't locate reallyReAlLyNotexists.pm in \@INC \(you may need to install the reallyReAlLyNotexists module\) \(\@INC[\w ]+:/}
     if 5.017005 <= $];
 
 eval q{use parent 'reallyReAlLyNotexists'};
@@ -74,4 +74,3 @@ like( $@, $expected, '  still failing on 2nd load');
     use parent -norequire, 'Has::Version_0';
     ::is( $Has::Version_0::VERSION, 0, '$VERSION==0 preserved' );
 }
-


### PR DESCRIPTION
In https://github.com/Perl/perl5/pull/20547 we are discussing changing the error message from `@INC contains:` to `@INC entries checked:`, and show what directories were checked during a failed required instead of the state of `@INC` at the end of the require as we used to, as INC hooks may modify `@INC` in flight, and there is a new hook facility which returns directories to search. 

This PR includes a version bump and Changes entry, but feel free to just cherry pick the patch if you prefer. 