### PR TITLE
t/: use the the "isnt" form rather than "isn't" due to deprecated '

### DIFF
--- a/t/parent-classfromclassfile.t
+++ b/t/parent-classfromclassfile.t
@@ -18,4 +18,4 @@ use_ok('parent');
 # and does not get treated as a file:
 eval q{package Test1; require Dummy; use parent -norequire, 'Dummy::InlineChild'; };
 is $@, '', "Loading an unadorned class works";
-isn't $INC{"Dummy.pm"}, undef, 'We loaded Dummy.pm';
+isnt $INC{"Dummy.pm"}, undef, 'We loaded Dummy.pm';

--- a/t/parent-classfromfile.t
+++ b/t/parent-classfromfile.t
@@ -20,6 +20,6 @@ my $base = './t';
 # and does not get treated as a file:
 eval sprintf q{package Test2; require '%s/lib/Dummy2.plugin'; use parent -norequire, 'Dummy2::InlineChild' }, $base;
 is $@, '', "Loading a class from a file works";
-isn't $INC{"$base/lib/Dummy2.plugin"}, undef, "We loaded the plugin file";
+isnt $INC{"$base/lib/Dummy2.plugin"}, undef, "We loaded the plugin file";
 my $o = bless {}, 'Test2';
 isa_ok $o, 'Dummy2::InlineChild';


### PR DESCRIPTION
Perl 5.38 (and current blead perl) deprecate use of ' to replace :: in symbol names.

This will produce an error from perl 5.40.